### PR TITLE
administración changed for gestion

### DIFF
--- a/src/app/shared/components/nav/nav.component.html
+++ b/src/app/shared/components/nav/nav.component.html
@@ -92,7 +92,7 @@
             class="underlineHover"
             type="button"
             routerLink="backoffice"
-            >Administración</a
+            >Gestión</a
           >
         </li>
       </ul>


### PR DESCRIPTION
Resumen

- Se cambió "administración" por "gestión" para mejorar el responsive al ser un nombre mas corto